### PR TITLE
Change map int to use Month to avoid confusion and useless conversions

### DIFF
--- a/models/statistics_report.go
+++ b/models/statistics_report.go
@@ -1,13 +1,15 @@
 package models
 
+import . "time"
+
 type StatisticsReport struct {
 
 	ClosedTransactions		int
 	AcceptedTransactions	int
 	RejectedTransactions	int
 
-	FirstYearAcceptedMonthlyFilings 	map[int]int
-	SecondYearAcceptedMonthlyFilings 	map[int]int
+	FirstYearAcceptedMonthlyFilings 	map[Month]int
+	SecondYearAcceptedMonthlyFilings 	map[Month]int
 }
 
 /*
@@ -19,8 +21,25 @@ func NewStatisticsReport() *StatisticsReport {
 		ClosedTransactions: 0,
 		AcceptedTransactions: 0,
 		RejectedTransactions: 0,
-		FirstYearAcceptedMonthlyFilings:  make(map[int]int, 0),
-		SecondYearAcceptedMonthlyFilings: make(map[int]int, 0),
+		FirstYearAcceptedMonthlyFilings:  initialiseMap(),
+		SecondYearAcceptedMonthlyFilings: initialiseMap(),
 	}
 }
 
+// Returns a map with months mapped to 0 values ready to be used.
+func initialiseMap() map[Month]int {
+	return map[Month]int{
+		January:	0,
+		February: 	0,
+		March: 		0,
+		April: 		0,
+		May: 		0,
+		June: 		0,
+		July:		0,
+		August:		0,
+		September: 	0,
+		October: 	0,
+		November: 	0,
+		December: 	0,
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -75,7 +75,7 @@ func sortTransactionsPerMonth(transactions *[]models.Transaction) *models.Statis
 
 			// If our transaction was closed within a year from today, then its added to our FirstYearFilings map.
 			if t.Data.ClosedAt.After(oneYearAgo) {
-				sr.FirstYearAcceptedMonthlyFilings[int(t.Data.ClosedAt.Month())]++
+				sr.FirstYearAcceptedMonthlyFilings[t.Data.ClosedAt.Month()]++
 			}
 
 			// Increase our accepted transactions by 1 each loop if we reach this point.
@@ -97,8 +97,8 @@ func printStatisticsReport(sr *models.StatisticsReport) {
 	log.Info(fmt.Sprintf("--- Statistics Report Tool ---"))
 	log.Info(fmt.Sprintf("--- Within 12 months Filings (Per Month) ---"))
 
-	for i, f := range sr.FirstYearAcceptedMonthlyFilings {
-		log.Info(fmt.Sprintf("%v Filings: %d", time.Month(i).String(), f))
+	for month, total := range sr.FirstYearAcceptedMonthlyFilings {
+		log.Info(fmt.Sprintf("%v Filings: %d", month.String(), total))
 	}
 
 	log.Info(fmt.Sprintf("--- Total: %d ---", sr.ClosedTransactions))

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -66,8 +66,7 @@ func testTransactionsSortsCorrectly(t *testing.T, transactions *[]models.Transac
 				c.So(sr.ClosedTransactions, c.ShouldEqual, 2)
 				c.So(sr.AcceptedTransactions, c.ShouldEqual, 1)
 				c.So(sr.RejectedTransactions, c.ShouldEqual, 1)
-				filingDateMonth := time.Month(2) // 2(february) is the filingDate Month found in createTransactionsSlice function below
-				c.So(sr.FirstYearAcceptedMonthlyFilings[int(filingDateMonth)], c.ShouldEqual, 1)
+				c.So(sr.FirstYearAcceptedMonthlyFilings[time.February], c.ShouldEqual, 1)
 			})
 		})
 	})
@@ -76,6 +75,7 @@ func testTransactionsSortsCorrectly(t *testing.T, transactions *[]models.Transac
 
 func createTransactionsSlice() *[]models.Transaction {
 
+	// filings date which will always be February just passed. (within a year).
 	filingDate := time.Date(time.Now().AddDate(0,-5,0).Year(),2, 1,0,0,0,0,time.UTC)
 
 	// Initialise empty slice of transactions.


### PR DESCRIPTION
This changes the int in the map of filings to Month (which is just a custom struct on top of an int). It makes it more readable and also avoids useless conversions